### PR TITLE
Update README.md, missing return statement in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const mainTemplate = prepareTemplate(
   {
     // A sub-template is a Renderer:
     A: (model, handlers, renderers) => {
-      evaluateTemplate(templateA, model, handlers, renderers);
+      return evaluateTemplate(templateA, model, handlers, renderers);
     }
   });
 ```


### PR DESCRIPTION
The example did not return the evaluated template.
